### PR TITLE
Change base image to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
       github="https://github.com/pltnk/docker-icecast2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 ## docker-icecast2
+
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
+[![Docker Image Size](https://img.shields.io/docker/image-size/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
+[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
+[![License](https://img.shields.io/github/license/pltnk/docker-icecast2)](https://choosealicense.com/licenses/mit/)
+
 Simple Dockerfile for running [icecast2](https://icecast.org/) in a container. \
 Just mount your icecast.xml file and you are good to go!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docker Image Size](https://img.shields.io/docker/image-size/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
 [![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/pltnk/icecast2)](https://hub.docker.com/r/pltnk/icecast2)
-[![License](https://img.shields.io/github/license/pltnk/docker-icecast2)](https://choosealicense.com/licenses/mit/)
+[![License](https://img.shields.io/github/license/pltnk/docker-icecast2)](https://github.com/pltnk/docker-icecast2/blob/master/LICENSE)
 
 Simple Dockerfile for running [icecast2](https://icecast.org/) in a container. \
 Just mount your icecast.xml file and you are good to go!


### PR DESCRIPTION
### Changed:
- Version of Ubuntu was changed from 18.04 to 20.04. Dockerfile that is based on Ubuntu 18.04 is available in [bionic branch](https://github.com/pltnk/docker-icecast2/tree/bionic). Built image on Docker Hub will be available by `bionic` tag.